### PR TITLE
Make `JSONNumber` to be opaque type.

### DIFF
--- a/Sources/JSONOperators.swift
+++ b/Sources/JSONOperators.swift
@@ -9,20 +9,20 @@
 public func == (a: JSONValue, b: JSONValue) -> Bool {
     typealias Value = JSONValue
     switch (a, b) {
-    case let (.null(l2),    .null(r2)):     return l2 == r2
-    case let (.boolean(l2), .boolean(r2)):  return l2 == r2
-    case let (.number(l2),  .number(r2)):   return l2 == r2
-    case let (.string(l2),  .string(r2)):   return l2 == r2
-    case let (.array(l2),   .array(r2)):    return l2 == r2
-    case let (.object(l2),  .object(r2)):   return l2 == r2
+    case let (.null(a1),    .null(b1)):     return a1 == b1
+    case let (.boolean(a1), .boolean(b1)):  return a1 == b1
+    case let (.number(a1),  .number(b1)):   return a1 == b1
+    case let (.string(a1),  .string(b1)):   return a1 == b1
+    case let (.array(a1),   .array(b1)):    return a1 == b1
+    case let (.object(a1),  .object(b1)):   return a1 == b1
     default:                                return false
     }
 }
 public func == (a: JSONNumber, b: JSONNumber) -> Bool {
     typealias Value = JSONNumber
-    switch (a, b) {
-    case let (.int64(l2),   .int64(r2)):    return l2 == r2
-    case let (.float64(l2), .float64(r2)):  return l2 == r2
+    switch (a.storage, b.storage) {
+    case let (.int64(a1),   .int64(b1)):    return a1 == b1
+    case let (.float64(a1), .float64(b1)):  return a1 == b1
     default:                                return false
     }
 }

--- a/Tests/AllTests/TestAll.swift
+++ b/Tests/AllTests/TestAll.swift
@@ -20,7 +20,50 @@ class EonilJSONTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
+//    func testJSONSerializerFragmentSupport() throws {
+//        let a = "AAA"
+//        let b = try JSONSerialization.data(withJSONObject: a, options: .prettyPrinted)
+//        let c = try JSONSerialization.jsonObject(with: b, options: .allowFragments)
+//        XCTAssertTrue(c is NSString)
+//        let c1 = c as? NSString as? String
+//        XCTAssertNotNil(c1)
+//        XCTAssertEqual(a, c1!)
+//    }
+    func testGoodNumberValue1() {
+        let a = Float64(11.11)
+        do {
+            let b = try JSONNumber(a)
+            XCTAssertNotNil(b.float64)
+            XCTAssertEqual(a, b.float64)
+        }
+        catch let e {
+            XCTFail("\(e)")
+        }
+    }
+    func testBadNumberValue1() {
+        let a = Float64.nan
+        XCTAssertThrowsError(try JSONNumber(a))
+    }
+    func testBadNumberValue2() {
+        let a = -Float64.nan
+        XCTAssertThrowsError(try JSONNumber(a))
+    }
+    func testBadNumberValue3() {
+        let a = Float64.infinity
+        XCTAssertThrowsError(try JSONNumber(a))
+    }
+    func testBadNumberValue4() {
+        let a = -Float64.infinity
+        XCTAssertThrowsError(try JSONNumber(a))
+    }
+    func testBadNumberValue5() {
+        let a = Float64(bitPattern: UInt64(0x0000000000000001))
+        let b = Float64(bitPattern: UInt64(0x000fffffffffffff))
+        XCTAssertThrowsError(try JSONNumber(a))
+        XCTAssertThrowsError(try JSONNumber(b))
+    }
+
 //    func testExample() {
 //        // This is an example of a functional test case.
 //        // Use XCTAssert and related functions to verify your tests produce the correct results.


### PR DESCRIPTION
- To prevent invalid input like `nan` or `infinity`.
- Add some test for it.